### PR TITLE
Implement Flask scheduling chatbot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+OPENAI_API_KEY=your-openai-key
+TWILIO_AUTH_TOKEN=your-twilio-auth-token
+DATABASE_PATH=appointments.db

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+__pycache__/
+appointments.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# scheduling_app
+# Scheduling Chatbot
+
+This project implements a simple WhatsApp scheduling assistant using Flask,
+Twilio and an OpenAI-compatible API (e.g. Grok API).
+
+## Features
+- Receive WhatsApp messages via Twilio webhook.
+- Use an LLM to understand booking requests and FAQs.
+- Store appointments in a local SQLite database.
+- Basic FAQ handling for shop hours, services and location.
+
+## Setup
+1. Create a virtual environment and install requirements:
+   ```bash
+   python -m venv venv
+   source venv/bin/activate
+   pip install -r requirements.txt
+   ```
+2. Create a `.env` file based on `.env.example` and fill in your keys:
+   - `OPENAI_API_KEY` – API key for Grok/OpenAI.
+   - `TWILIO_AUTH_TOKEN` – used to verify Twilio requests (optional).
+   - `DATABASE_PATH` – path to SQLite DB (default `appointments.db`).
+3. Run the application:
+   ```bash
+   flask run
+   ```
+   The app listens on `/webhook` for POST requests from Twilio.
+
+## Deployment
+You can deploy this on platforms such as Replit or Render. Ensure you set the
+above environment variables in the service's dashboard and expose the `/webhook`
+endpoint to Twilio.
+
+## Notes
+- For production, secure the webhook using Twilio request validation.
+- The LLM prompt expects JSON output; adjust as needed for your model.
+- You can expand `check_availability` to integrate with Google Calendar.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,136 @@
+import os
+from flask import Flask, request
+from twilio.twiml.messaging_response import MessagingResponse
+from dotenv import load_dotenv
+import openai
+import sqlite3
+import logging
+
+load_dotenv()
+
+app = Flask(__name__)
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+DATABASE = os.getenv("DATABASE_PATH", "appointments.db")
+
+logging.basicConfig(level=logging.INFO)
+
+
+def init_db():
+    conn = sqlite3.connect(DATABASE)
+    c = conn.cursor()
+    c.execute(
+        """
+        CREATE TABLE IF NOT EXISTS appointments (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            phone TEXT,
+            name TEXT,
+            service TEXT,
+            date TEXT,
+            time TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def parse_message(message: str) -> dict:
+    prompt = f"""
+    Extract intent and entities from the user's message.
+    Return JSON with fields: intent (book, cancel, info), service, date, time, name.
+    Message: \"{message}\"
+    """
+    try:
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.2,
+        )
+        content = response.choices[0].message["content"]
+        import json
+
+        data = json.loads(content)
+        return data
+    except Exception:
+        logging.exception("LLM parsing error")
+        return {}
+
+
+def check_availability(date: str, time: str) -> bool:
+    conn = sqlite3.connect(DATABASE)
+    c = conn.cursor()
+    c.execute("SELECT 1 FROM appointments WHERE date=? AND time=?", (date, time))
+    available = c.fetchone() is None
+    conn.close()
+    return available
+
+
+def save_appointment(phone: str, name: str, service: str, date: str, time: str) -> None:
+    conn = sqlite3.connect(DATABASE)
+    c = conn.cursor()
+    c.execute(
+        "INSERT INTO appointments (phone, name, service, date, time) VALUES (?, ?, ?, ?, ?)",
+        (phone, name, service, date, time),
+    )
+    conn.commit()
+    conn.close()
+
+
+FAQ_RESPONSES = {
+    "hours": "We are open Tuesday to Saturday 9AM - 6PM.",
+    "services": "We offer haircuts, coloring, and styling.",
+    "location": "We are located at 123 Main St.",
+}
+
+
+@app.route("/webhook", methods=["POST"])
+def webhook():
+    init_db()
+    from_number = request.form.get("From")
+    body = request.form.get("Body", "")
+    logging.info("Incoming message from %s: %s", from_number, body)
+
+    resp = MessagingResponse()
+
+    lower_body = body.lower().strip()
+    if lower_body in FAQ_RESPONSES:
+        resp.message(FAQ_RESPONSES[lower_body])
+        return str(resp)
+
+    parsed = parse_message(body)
+    intent = parsed.get("intent")
+
+    if intent == "book":
+        service = parsed.get("service")
+        date = parsed.get("date")
+        time_str = parsed.get("time")
+        name = parsed.get("name", from_number)
+
+        if not all([service, date, time_str]):
+            resp.message(
+                "Sorry, I couldn't understand your request. Please provide service, date, and time."
+            )
+            return str(resp)
+
+        if check_availability(date, time_str):
+            save_appointment(from_number, name, service, date, time_str)
+            resp.message(f"Confirmed {service} on {date} at {time_str} for {name}.")
+        else:
+            resp.message(
+                "Sorry, that slot is not available. Please choose another time."
+            )
+    elif intent == "cancel":
+        resp.message("To cancel, please contact the shop directly.")
+    elif intent == "info":
+        resp.message("You can ask about our hours, services, or location.")
+    else:
+        resp.message(
+            "Sorry, I didn't understand that. Please try again or contact the shop."
+        )
+
+    return str(resp)
+
+
+if __name__ == "__main__":
+    app.run(debug=True, port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+python-dotenv
+openai
+Twilio


### PR DESCRIPTION
## Summary
- create Flask app that handles WhatsApp webhook and parses messages with an LLM
- save appointments in SQLite and reply via Twilio
- document setup and deployment
- provide example environment file and requirements
- ignore local artifacts in git

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686eab8091308328b08e7971cb4aae49